### PR TITLE
remove a compile warning under Linux

### DIFF
--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -45,7 +45,9 @@ typedef int bool;
 #define false 0
 #endif
 
+#ifndef M_PI
 #define M_PI (3.14159265359)
+#endif
 
 #define MAX(a,b) ((a) > (b) ? a : b)
 #define MIN(a,b) ((a) < (b) ? a : b)


### PR DESCRIPTION
```
mzs@bananapi:~/src/airspyhf/build$ make
Scanning dependencies of target airspyhf
[ 25%] Building C object libairspyhf/src/CMakeFiles/airspyhf.dir/airspyhf.c.o
/home/mzs/src/airspyhf/libairspyhf/src/airspyhf.c:48:0: warning: "M_PI" redefined
 #define M_PI (3.14159265359)
 ^
In file included from /home/mzs/src/airspyhf/libairspyhf/src/airspyhf.c:36:0:
/usr/include/math.h:372:0: note: this is the location of the previous definition
 # define M_PI  3.14159265358979323846 /* pi */
 ^
[ 50%] Building C object libairspyhf/src/CMakeFiles/airspyhf.dir/iqbalancer.c.o
Linking C shared library libairspyhf.so
[ 50%] Built target airspyhf
Scanning dependencies of target airspyhf-static
[ 75%] Building C object libairspyhf/src/CMakeFiles/airspyhf-static.dir/airspyhf.c.o
/home/mzs/src/airspyhf/libairspyhf/src/airspyhf.c:48:0: warning: "M_PI" redefined
 #define M_PI (3.14159265359)
 ^
In file included from /home/mzs/src/airspyhf/libairspyhf/src/airspyhf.c:36:0:
/usr/include/math.h:372:0: note: this is the location of the previous definition
 # define M_PI  3.14159265358979323846 /* pi */
 ^
[100%] Building C object libairspyhf/src/CMakeFiles/airspyhf-static.dir/iqbalancer.c.o
Linking C static library libairspyhf.a
[100%] Built target airspyhf-static
mzs@bananapi:~/src/airspyhf/build$
```

As I submit this patch, looking at the above warning message now I'm starting to wondering if the intent is actually to redefine M_PI as 3.14159265359 instead of 3.14159265358979323846 that there is some advantage, I have not read through the code (yet).