### PR TITLE
airspyhf_list_devices() with NULL to only get the number of devices

### DIFF
--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -728,7 +728,10 @@ int airspyhf_list_devices(uint64_t *serials, int count)
 	int i;
 	unsigned char serial_number[AIRSPYHF_SERIAL_SIZE + 1];
 
-	memset(serials, 0, sizeof(uint64_t) * count);
+	if (serials)
+	{
+		memset(serials, 0, sizeof(uint64_t) * count);
+	}
 
 	if (libusb_init(&context) != 0)
 	{
@@ -742,7 +745,7 @@ int airspyhf_list_devices(uint64_t *serials, int count)
 
 	i = 0;
 	output_count = 0;
-	while ((dev = devices[i++]) != NULL && output_count < count)
+	while ((dev = devices[i++]) != NULL && (!serials || output_count < count))
 	{
 		libusb_get_device_descriptor(dev, &device_descriptor);
 
@@ -777,7 +780,10 @@ int airspyhf_list_devices(uint64_t *serials, int count)
 						continue;
 					}
 
-					serials[output_count] = serial;
+					if (serials)
+					{
+						serials[output_count] = serial;
+					}
 					output_count++;
 				}
 


### PR DESCRIPTION
A little improvement proposal for airspyhf_list_devices() to accept NULL as serials pointer to only get the number of devices. If serials is NULL the count parameter is also ignored.

This won't change the normal behavior when giving a serials pointer, but will allow to get only the number of devices, for example to dynamically allocate the serials array instead of using a fixed sized one.