### PR TITLE
fix: change freeing sequence in airspyhf_close()

### DIFF
--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -985,11 +985,11 @@ int ADDCALL airspyhf_close(airspyhf_device_t* device)
 		pthread_cond_destroy(&device->consumer_cv);
 		pthread_mutex_destroy(&device->consumer_mp);
 
-		airspyhf_open_exit(device);
 		free_transfers(device);
 		free(device->supported_samplerates);
 		free(device->samplerate_architectures);
 		iq_balancer_destroy(device->iq_balancer);
+		airspyhf_open_exit(device);
 		free(device);
 	}
 


### PR DESCRIPTION
### Symptoms

libusb-1.0.25 causes SIGSEGV when calling airspyhf_close(). See https://github.com/libusb/libusb/issues/1059 for the details. The same bugs are reported for [airspy-fmradion on macOS](https://github.com/jj1bdx/airspy-fmradion/issues/35) and [SDR++ on ArchLinux](https://github.com/libusb/libusb/issues/1059#issuecomment-1030638617) after the update of libusb from 1.0.24 to 1.0.25.

### Analysis

* libusb_free_transfer() called from airspyhf_close caused SIGSEGV in libusb 1.0.25
* libusb_exit()'s context should not be freed before freeing the transfers

### Proposed fix

* In this fix, the airspyhf_open_exit() calling point is moved after all the other objects are freed except the device itself.
* This fix solves the airspy-fmradion's issue on macOS.