### PR TITLE
fix hang issue when device is disconnected

### DIFF
--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -433,12 +433,12 @@ static void airspyhf_libusb_transfer_callback(struct libusb_transfer* usb_transf
 
 		if (libusb_submit_transfer(usb_transfer) != 0)
 		{
-			device->streaming = false;
+			device->stop_requested = true;
 		}
 	}
 	else
 	{
-		device->streaming = false;
+		device->stop_requested = true;
 	}
 }
 
@@ -1170,7 +1170,7 @@ int ADDCALL airspyhf_start(airspyhf_device_t* device, airspyhf_sample_block_cb_f
 
 int ADDCALL airspyhf_is_streaming(airspyhf_device_t* device)
 {
-	return device->streaming;
+	return device->streaming && !device->stop_requested;
 }
 
 int ADDCALL airspyhf_stop(airspyhf_device_t* device)

--- a/libairspyhf/src/airspyhf.h
+++ b/libairspyhf/src/airspyhf.h
@@ -122,6 +122,9 @@ extern ADDAPI void ADDCALL airspyhf_lib_version(airspyhf_lib_version_t* lib_vers
 extern ADDAPI int ADDCALL airspyhf_list_devices(uint64_t *serials, int count);
 extern ADDAPI int ADDCALL airspyhf_open(airspyhf_device_t** device);
 extern ADDAPI int ADDCALL airspyhf_open_sn(airspyhf_device_t** device, uint64_t serial_number);
+#ifndef _WIN32
+extern ADDAPI int ADDCALL airspyhf_open_file_descriptor(airspyhf_device_t** device, int fd);
+#endif
 extern ADDAPI int ADDCALL airspyhf_close(airspyhf_device_t* device);
 extern ADDAPI int ADDCALL airspyhf_get_output_size(airspyhf_device_t* device); /* Returns the number of IQ samples to expect in the callback */
 extern ADDAPI int ADDCALL airspyhf_start(airspyhf_device_t* device, airspyhf_sample_block_cb_fn callback, void* ctx);


### PR DESCRIPTION
Hi, I experienced that airspyhf_rx and other sofware is hanging when the airspyhf was disconnected during streaming. After some investigation I realized that kill_io_threads was not terminating the consumer_thread and then a later pthread_cond_signal call was hanging the system (undefined behavior because a thread still waiting for the signal). 

I believe the issue might be resolved if the variable streaming is true if and only if the threads are running and stop_requested is used to indicate a request to stop (e.g. because there is an issue with the device).

For your kind consideration. Jasper 