### PR TITLE
When building against airspyhf, link against libm

### DIFF
--- a/libairspyhf/libairspyhf.pc.in
+++ b/libairspyhf/libairspyhf.pc.in
@@ -7,5 +7,5 @@ Name: AirSpy HF+ Library
 Description: C Utility Library
 Version: @VERSION@
 Cflags: -I${includedir}/libairspyhf/ @AIRSPYHF_PC_CFLAGS@
-Libs: -L${libdir} -lairspyhf
+Libs: -L${libdir} -lairspyhf -lm
 Libs.private: @AIRSPYHF_PC_LIBS@


### PR DESCRIPTION
Given a minimal example program such as:

```c
  #include <airspyhf.h>
  void main(int argc, char** argv) {
      airspyhf_lib_version_t v;
      airspyhf_lib_version(&v);
  }
```

And when compiled with pkg-config, the following error is returned:

```
  $ gcc airspy.c -o airspy $(pkg-config --cflags --libs libairspyhf)
  /usr/bin/ld: .../libairspyhf.so: undefined reference to `sincos'
  /usr/bin/ld: .../libairspyhf.so: undefined reference to `powf'
  /usr/bin/ld: .../libairspyhf.so: undefined reference to `exp'
  /usr/bin/ld: .../libairspyhf.so: undefined reference to `cos'
  collect2: error: ld returned 1 exit status
```

This changeset adds in a link directive against libm, which provides the math
helpers in `<math.h>`. Granted; most user-programs already use libm, since, well,
raw IQ without math isn't very fun at all, so this is masked in the vast
majority of use-cases. However, in the spirit of ensuring that we're as
complete as we can, this change will allow pkg-config to return all libraries
required for linking against `libairspyhf` without requiring extra user provided
library flags.