### PR TITLE
Non-root android support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "xhash": "c",
+        "xutility": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "xhash": "c",
-        "xutility": "c"
-    }
-}

--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -759,38 +759,38 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 	int result;
 
 	result = libusb_wrap_sys_device(device->usb_context, (intptr_t)fd, &device->usb_device);
-	if (result != 0 || device->usb_device == NULL)
-	{
-		*ret = AIRSPYHF_ERROR;
-		return;
-	}
+	// if (result != 0 || device->usb_device == NULL)
+	// {
+	// 	*ret = AIRSPYHF_ERROR;
+	// 	return;
+	// }
 
 	result = libusb_set_configuration(device->usb_device, 1);
-	if (result != 0)
-	{
-		libusb_close(device->usb_device);
-		device->usb_device = NULL;
-		*ret = AIRSPYHF_ERROR;
-		return;
-	}
+	// if (result != 0)
+	// {
+	// 	libusb_close(device->usb_device);
+	// 	device->usb_device = NULL;
+	// 	*ret = AIRSPYHF_ERROR;
+	// 	return;
+	// }
 	
 	result = libusb_claim_interface(device->usb_device, 0);
-	if (result != 0)
-	{
-		libusb_close(device->usb_device);
-		device->usb_device = NULL;
-		*ret = AIRSPYHF_ERROR;
-		return;
-	}
+	// if (result != 0)
+	// {
+	// 	libusb_close(device->usb_device);
+	// 	device->usb_device = NULL;
+	// 	*ret = AIRSPYHF_ERROR;
+	// 	return;
+	// }
 
 	result = libusb_set_interface_alt_setting(device->usb_device, 0, 1);
-	if (result != 0)
-	{
-		libusb_close(device->usb_device);
-		device->usb_device = NULL;
-		*ret = AIRSPYHF_ERROR;
-		return;
-	}
+	// if (result != 0)
+	// {
+	// 	libusb_close(device->usb_device);
+	// 	device->usb_device = NULL;
+	// 	*ret = AIRSPYHF_ERROR;
+	// 	return;
+	// }
 
 	*ret = AIRSPYHF_SUCCESS;
 	return;

--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -815,6 +815,11 @@ int airspyhf_list_devices(uint64_t *serials, int count)
 		memset(serials, 0, sizeof(uint64_t) * count);
 	}
 
+#ifdef __ANDROID__
+	// LibUSB does not support device discovery on android
+	libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY, NULL);
+#endif
+
 	if (libusb_init(&context) != 0)
 	{
 		return AIRSPYHF_ERROR;

--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -758,7 +758,7 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 	int fd) {
 	int result;
 
-	result libusb_wrap_sys_device(device->usb_context, (intptr_t)fd, &device->usb_device);
+	result = libusb_wrap_sys_device(device->usb_context, (intptr_t)fd, &device->usb_device);
 	if (result != 0 || device->usb_device == NULL)
 	{
 		*ret = AIRSPYHF_ERROR;
@@ -773,7 +773,7 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 		return;
 	}
 	
-	libusb_claim_interface(device->usb_device, 0);
+	result = libusb_claim_interface(device->usb_device, 0);
 	if (result != 0)
 	{
 		libusb_close(device->usb_device);
@@ -781,7 +781,7 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 		return;
 	}
 
-	libusb_set_interface_alt_setting(device->usb_device, 0, 1);
+	result = libusb_set_interface_alt_setting(device->usb_device, 0, 1);
 	if (result != 0)
 	{
 		libusb_close(device->usb_device);

--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -758,7 +758,7 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 	int fd) {
 	int result;
 
-	result libusb_wrap_sys_device(device->usb_context, (intptr_t)serial_number_val, &device->usb_device);
+	result libusb_wrap_sys_device(device->usb_context, (intptr_t)fd, &device->usb_device);
 	if (result != 0 || device->usb_device == NULL)
 	{
 		*ret = AIRSPYHF_ERROR;

--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -759,38 +759,38 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 	int result;
 
 	result = libusb_wrap_sys_device(device->usb_context, (intptr_t)fd, &device->usb_device);
-	// if (result != 0 || device->usb_device == NULL)
-	// {
-	// 	*ret = AIRSPYHF_ERROR;
-	// 	return;
-	// }
+	if (result != 0 || device->usb_device == NULL)
+	{
+		*ret = AIRSPYHF_ERROR;
+		return;
+	}
 
 	result = libusb_set_configuration(device->usb_device, 1);
-	// if (result != 0)
-	// {
-	// 	libusb_close(device->usb_device);
-	// 	device->usb_device = NULL;
-	// 	*ret = AIRSPYHF_ERROR;
-	// 	return;
-	// }
+	if (result != 0)
+	{
+		libusb_close(device->usb_device);
+		device->usb_device = NULL;
+		*ret = AIRSPYHF_ERROR;
+		return;
+	}
 	
 	result = libusb_claim_interface(device->usb_device, 0);
-	// if (result != 0)
-	// {
-	// 	libusb_close(device->usb_device);
-	// 	device->usb_device = NULL;
-	// 	*ret = AIRSPYHF_ERROR;
-	// 	return;
-	// }
+	if (result != 0)
+	{
+		libusb_close(device->usb_device);
+		device->usb_device = NULL;
+		*ret = AIRSPYHF_ERROR;
+		return;
+	}
 
 	result = libusb_set_interface_alt_setting(device->usb_device, 0, 1);
-	// if (result != 0)
-	// {
-	// 	libusb_close(device->usb_device);
-	// 	device->usb_device = NULL;
-	// 	*ret = AIRSPYHF_ERROR;
-	// 	return;
-	// }
+	if (result != 0)
+	{
+		libusb_close(device->usb_device);
+		device->usb_device = NULL;
+		*ret = AIRSPYHF_ERROR;
+		return;
+	}
 
 	*ret = AIRSPYHF_SUCCESS;
 	return;

--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -769,6 +769,7 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 	if (result != 0)
 	{
 		libusb_close(device->usb_device);
+		device->usb_device = NULL;
 		*ret = AIRSPYHF_ERROR;
 		return;
 	}
@@ -777,6 +778,7 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 	if (result != 0)
 	{
 		libusb_close(device->usb_device);
+		device->usb_device = NULL;
 		*ret = AIRSPYHF_ERROR;
 		return;
 	}
@@ -785,6 +787,7 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 	if (result != 0)
 	{
 		libusb_close(device->usb_device);
+		device->usb_device = NULL;
 		*ret = AIRSPYHF_ERROR;
 		return;
 	}

--- a/libairspyhf/src/airspyhf.h
+++ b/libairspyhf/src/airspyhf.h
@@ -123,6 +123,7 @@ extern ADDAPI void ADDCALL airspyhf_lib_version(airspyhf_lib_version_t* lib_vers
 extern ADDAPI int ADDCALL airspyhf_list_devices(uint64_t *serials, int count);
 extern ADDAPI int ADDCALL airspyhf_open(airspyhf_device_t** device);
 extern ADDAPI int ADDCALL airspyhf_open_sn(airspyhf_device_t** device, uint64_t serial_number);
+extern ADDAPI int ADDCALL airspyhf_open_fd(airspyhf_device_t** device, int fd);
 extern ADDAPI int ADDCALL airspyhf_close(airspyhf_device_t* device);
 extern ADDAPI int ADDCALL airspyhf_get_output_size(airspyhf_device_t* device); /* Returns the number of IQ samples to expect in the callback */
 extern ADDAPI int ADDCALL airspyhf_start(airspyhf_device_t* device, airspyhf_sample_block_cb_fn callback, void* ctx);


### PR DESCRIPTION
This PR contains the following modifications:

1) Disabled libusb enumeration when compiling on android since it is not supported (As explained [in the libusb documentation](https://github.com/libusb/libusb/blob/master/android/README) line 92)
2) Add the `airspyhf_open_fd` function that allows to open an Airspy HF+ device using a file descriptor. This is the only possible way to open a usb device on a non-rooted android device.

I tried to do these modifications in such a way that they modify as few lines as possible. Feel free to let me know if the exact manner it was implemented is not in line with the project's code style.

This code has been tested and confirmed working on several android device but I still recommend testing it further.
It should not impact any other operating system.

