### PR TITLE
Link against libm if needed

### DIFF
--- a/libairspyhf/src/CMakeLists.txt
+++ b/libairspyhf/src/CMakeLists.txt
@@ -57,6 +57,27 @@ endif()
 set_target_properties(airspyhf PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 set_target_properties(airspyhf-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 
+include(CheckFunctionExists)
+
+if(NOT COS_FUNCTION_EXISTS AND NOT NEED_LINKING_AGAINST_LIBM)
+  CHECK_FUNCTION_EXISTS(cos COS_FUNCTION_EXISTS)
+  if(NOT COS_FUNCTION_EXISTS)
+    unset(COS_FUNCTION_EXISTS CACHE)
+      list(APPEND CMAKE_REQUIRED_LIBRARIES m)
+      CHECK_FUNCTION_EXISTS(cos COS_FUNCTION_EXISTS)
+      if(COS_FUNCTION_EXISTS)
+          set(NEED_LINKING_AGAINST_LIBM True CACHE BOOL "" FORCE)
+      else()
+          message(FATAL_ERROR "Failed making the cos() function available")
+      endif()
+  endif()
+endif()
+
+if (NEED_LINKING_AGAINST_LIBM)
+     target_link_libraries(airspyhf m)
+endif()
+
+
 # Dependencies
 target_link_libraries(airspyhf ${LIBUSB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 

--- a/tools/52-airspyhf.rules
+++ b/tools/52-airspyhf.rules
@@ -1,1 +1,1 @@
-ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", MODE="660", GROUP="plugdev"
+ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", TAG+="uaccess"


### PR DESCRIPTION
This seems to be needed on fedora.

Also switches udev rules to use uaccess. Also needed on fedora, but I haven't tested on ubuntu/debian.