### PR TITLE
Improved compatibility for older libusb versions on linux

### DIFF
--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -758,7 +758,7 @@ static void airspyhf_open_device_fd(airspyhf_device_t* device,
 	int fd) {
 	int result = -1;
 
-#ifndef _WIN32
+#ifdef __ANDROID__
 	result = libusb_wrap_sys_device(device->usb_context, (intptr_t)fd, &device->usb_device);
 #else
 	device->usb_device = NULL;


### PR DESCRIPTION
This only enables the `airspyhf_open_device_fd` function on android since it's the only operating system where it's needed. This fixes the issues some users of older systems have had where `libusb_wrap_sys_device` is not available.