### PR TITLE
Increase SAMPLES_TO_TRANSFER

### DIFF
--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -52,7 +52,7 @@ typedef int bool;
 #define MAX(a,b) ((a) > (b) ? a : b)
 #define MIN(a,b) ((a) < (b) ? a : b)
 
-#define SAMPLES_TO_TRANSFER (1024 * 2)
+#define SAMPLES_TO_TRANSFER (1024 * 16)
 #define SERIAL_NUMBER_UNUSED (0)
 #define FILE_DESCRIPTOR_UNUSED (-1)
 #define RAW_BUFFER_COUNT (8)


### PR DESCRIPTION
I was seeing `SoapySDR readStream failed: OVERFLOW` appear in my logs with some frequency while using SoapSDR + Soapy AirSpyHF in conjunction with dumphfdl. I realize the issue is likely my computer is being hamstrung in some way (CPU usage or USB bus being slow).

Increasing the buffer size appears to solve the issue and allow the program to keep up with the buffer.