### PR TITLE
Revert udev rules change, add notes on udev issues for non-Debian distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Debug version:
 
 `sudo ldconfig`
 
+Users of non-Debian-based distrbutions (Fedora, etc), or distributions that don't use the plugdev group may need to modify the udev rules file to use the [uaccess paradigm](https://github.com/systemd/systemd/issues/4288). This can be performed by editing the udev rules file:
+
+`sudo nano /etc/udev/rules.d/52-airspyhf.rules` 
+
+... and replacing the contents with: `ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", TAG+="uaccess"`
+Device access should then work for users logging in locally, but may not work for ssh logins, or systemd services.
+
 ## Clean CMake temporary files/dirs:
 
 `cd airspyhf-master/build`

--- a/tools/52-airspyhf.rules
+++ b/tools/52-airspyhf.rules
@@ -1,1 +1,1 @@
-ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", TAG+="uaccess"
+ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", MODE="660", GROUP="plugdev"


### PR DESCRIPTION
The udev rule currently shipped with this repository does not work correctly on Debian / Raspbian systems. 
As a non-root user, the Airspy HF cannot be accessed when logging in via SSH, or accessing an Airspy HF via a systemd service. 

The udev rule was changed from using the plugdev group permissions to using the uaccess paradigm in PR https://github.com/airspy/airspyhf/pull/43 .
There is discussion around the changes to the uaccess approach in this issue: https://github.com/airspy/airspyhf/issues/46

While uaccess is probably the 'right' way to move with udev permissions, at the moment it seems that it only works for users logged in locally (e.g. keyboard/mouse, or a KVM), and there is not a workable solution for access permissions for users logged in via SSH, or for processes running as a systemd service. 

The example case where this causes issues is in the setup of a SpyServer, e.g. using the [helper script](http://airspy.com/downloads/install-spyserver-rpi.sh) linked to in the [Airspy QuickStart guide](https://airspy.com/quickstart/). Running this helper script on a fresh Raspbian installation results in a broken SpyServer systemd service, which cannot access the Airspy HF. (It works fine with Airspy R2, because the udev rules in [that repository](https://github.com/airspy/airspyone_host/blob/master/airspy-tools/52-airspy.rules) were never changed. )

This PR:
* Reverts the udev rule back to the previous approach, using the plugdev group. **This is the same approach currently used in the [airspyone_host repository](https://github.com/airspy/airspyone_host/blob/master/airspy-tools/52-airspy.rules)**, and will make the recommended setup script on the AirSpy QuickStart page work again.
* Adds notes in the Linux installation section of the README describing what changes may need to be made on non-Debian distributions, or distributions that do not have a plugdev group.


