### PR TITLE
Update airspyhf_rx.c

### DIFF
--- a/tools/src/airspyhf_rx.c
+++ b/tools/src/airspyhf_rx.c
@@ -37,10 +37,12 @@
 #include <airspyhf.h>
 
 #if !defined __cplusplus
+#if __STDC_VERSION__ < 202311L
 #ifndef bool
 typedef int bool;
 #define true 1
 #define false 0
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Adds check to see if stdc version is older than c23 prior to applying  the definition of bool. bool is a keyword in c23 and later and causes an error during compilation. This allows c23 and later to ignore the definition block.