### PR TITLE
Dynamically create/install udev rules file depending upon usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #top dir cmake project for libairspyhf
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 project (airspyhf_all)
 
 #provide missing strtoull() for VC11

--- a/README.md
+++ b/README.md
@@ -70,12 +70,9 @@ Debug version:
 
 `sudo ldconfig`
 
-Note: Users of Linux systems, that employ their AirspyHF+ for networked operation require an extra level of security for their
-device. By using the cmake option `-DREMOTE_USER_RULES=ON` the build process will dynamically change and install the udev rules
-such that the device is created with MODE=660, GROUP=plugdev, rather than the default `uaccess` paradigm.
+Note: Users of Linux systems, that employ their AirspyHF+ for networked operation require an extra level of security for their device. By using the cmake option `-DREMOTE_USER_RULES=ON` the build process will dynamically change and install the udev rules such that the device is created with MODE=660, GROUP=plugdev, rather than the default `uaccess` paradigm.
 
-Users can reverse this to the default `uaccess` setting by using `-DREMOTE_USER_RULES=OFF`, but also including
-`-DINSTALL_UDEV_RULES=ON` to re-install it.
+Users can reverse this to the default `uaccess` setting by using `-DREMOTE_USER_RULES=OFF`, but also including `-DINSTALL_UDEV_RULES=ON` to re-install it.
 
 ## Clean CMake temporary files/dirs:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Debug version:
 `cd build`
 
 `cmake ../ -DINSTALL_UDEV_RULES=ON` or
-`cmake ../ -REMOTE_USER_RULES=ON` (see below)
+`cmake ../ -REMOTE_USER_RULES=ON|OFF` (see below)
 
 `make`
 
@@ -73,6 +73,9 @@ Debug version:
 Note: Users of Linux systems, that employ their AirspyHF+ for networked operation require an extra level of security for their
 device. By using the cmake option `-DREMOTE_USER_RULES=ON` the build process will dynamically change and install the udev rules
 such that the device is created with MODE=660, GROUP=plugdev, rather than the default `uaccess` paradigm.
+
+Users can reverse this to the default `uaccess` setting by using `-DREMOTE_USER_RULES=OFF`, but also including
+`-DINSTALL_UDEV_RULES=ON` to re-install it.
 
 ## Clean CMake temporary files/dirs:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Debug version:
 
 `sudo ldconfig`
 
-Note: The default installation is designed for networked systems, such as SpyServers, that require an extra level of security to access their device. As such, using the cmake option `-DINSTALL_UDEV_RULES=ON` will allow read/write permissions only for the logged in user and those that are included in the `plugdev` group. If this default MODE/GROUP paradigm is employed, it is up to the system admistrator to ensure that the `plugdev` group is both created, and that all local and/or remote users are subsequently added to that group. 
+Note: The default installation is designed for networked systems, such as SpyServers, that require an extra level of security to access their device. As such, using the cmake option `-DINSTALL_UDEV_RULES=ON` will allow read/write permissions only for the logged in user and those that are included in the `plugdev` group. If this default MODE/GROUP paradigm is employed, the `plugdev` group will be automatically created during the installation phase. However, it is up to the system admistrator to ensure that all local and/or remote users are subsequently added to that group.
 
 Conversely, Users of stand-alone non-Debian-based Linux systems may require less stringent `uaccess` udev rules in order for applications to 'see' the device. By using the cmake option `-DUSE_UACCESS_RULES=ON` the build process will dynamically change and install the udev rules such that the device is created using the `uaccess` paradigm, instead of the default MODE/GROUP.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Debug version:
 `cd build`
 
 `cmake ../ -DINSTALL_UDEV_RULES=ON` or
-`cmake ../ -REMOTE_USER_RULES=ON|OFF` (see below)
+`cmake ../ -USE_UACCESS_RULES=ON` (see below)
 
 `make`
 
@@ -70,9 +70,11 @@ Debug version:
 
 `sudo ldconfig`
 
-Note: Users of Linux systems, that employ their AirspyHF+ for networked operation require an extra level of security for their device. By using the cmake option `-DREMOTE_USER_RULES=ON` the build process will dynamically change and install the udev rules such that the device is created with MODE=660, GROUP=plugdev, rather than the default `uaccess` paradigm.
+Note: The default installation is designed for networked systems, such as SpyServers, that require an extra level of security to access their device. As such, using the cmake option `-DINSTALL_UDEV_RULES=ON` will allow read/write permissions only for the logged in user and those that are included in the `plugdev` group. If this default MODE/GROUP paradigm is employed, it is up to the system admistrator to ensure that the `plugdev` group is both created, and that all local and/or remote users are subsequently added to that group. 
 
-Users can reverse this to the default `uaccess` setting by using `-DREMOTE_USER_RULES=OFF`, but also including `-DINSTALL_UDEV_RULES=ON` to re-install it.
+Conversely, Users of stand-alone non-Debian-based Linux systems may require less stringent `uaccess` udev rules in order for applications to 'see' the device. By using the cmake option `-DUSE_UACCESS_RULES=ON` the build process will dynamically change and install the udev rules such that the device is created using the `uaccess` paradigm, instead of the default MODE/GROUP.
+
+This can later be reversed to use the default MODE/GROUP paradigm, if needed, by rebuilding with the `-DUSE_UACCESS_RULES=OFF -DINSTALL_UDEV_RULES=ON` options to restore and re-install it.
 
 ## Clean CMake temporary files/dirs:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Debug version:
 
 `cd build`
 
-`cmake ../ -DINSTALL_UDEV_RULES=ON`
+`cmake ../ -DINSTALL_UDEV_RULES=ON` or
+`cmake ../ -REMOTE_USER_RULES=ON` (see below)
 
 `make`
 
@@ -69,12 +70,9 @@ Debug version:
 
 `sudo ldconfig`
 
-Users of non-Debian-based distrbutions (Fedora, etc), or distributions that don't use the plugdev group may need to modify the udev rules file to use the [uaccess paradigm](https://github.com/systemd/systemd/issues/4288). This can be performed by editing the udev rules file:
-
-`sudo nano /etc/udev/rules.d/52-airspyhf.rules` 
-
-... and replacing the contents with: `ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", TAG+="uaccess"`
-Device access should then work for users logging in locally, but may not work for ssh logins, or systemd services.
+Note: Users of Linux systems, that employ their AirspyHF+ for networked operation require an extra level of security for their
+device. By using the cmake option `-DREMOTE_USER_RULES=ON` the build process will dynamically change and install the udev rules
+such that the device is created with MODE=660, GROUP=plugdev, rather than the default `uaccess` paradigm.
 
 ## Clean CMake temporary files/dirs:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Debug version:
 `cd build`
 
 `cmake ../ -DINSTALL_UDEV_RULES=ON` or
-`cmake ../ -USE_UACCESS_RULES=ON` (see below)
+`cmake ../ -USE_UACCESS_RULES=ON` or
+`cmake ../` (see usage notes below)
 
 `make`
 
@@ -75,6 +76,8 @@ Note: The default installation is designed for networked systems, such as SpySer
 Conversely, Users of stand-alone non-Debian-based Linux systems may require less stringent `uaccess` udev rules in order for applications to 'see' the device. By using the cmake option `-DUSE_UACCESS_RULES=ON` the build process will dynamically change and install the udev rules such that the device is created using the `uaccess` paradigm, instead of the default MODE/GROUP.
 
 This can later be reversed to use the default MODE/GROUP paradigm, if needed, by rebuilding with the `-DUSE_UACCESS_RULES=OFF -DINSTALL_UDEV_RULES=ON` options to restore and re-install it.
+
+MacOS deals with communicating with USB devices much differently than Linux. Therefore none of these udev options are required when running `cmake` on Macs.
 
 ## Clean CMake temporary files/dirs:
 

--- a/libairspyhf/CMakeLists.txt
+++ b/libairspyhf/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 project(libairspyhf C)
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/src/airspyhf.h AIRSPYHF_H_CONTENTS)
 

--- a/tools/52-airspyhf.rules
+++ b/tools/52-airspyhf.rules
@@ -1,1 +1,1 @@
-ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", TAGS+="uaccess"
+ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", MODE="660", GROUP="plugdev"

--- a/tools/52-airspyhf.rules
+++ b/tools/52-airspyhf.rules
@@ -1,1 +1,1 @@
-ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", MODE="660", GROUP="plugdev"
+ATTR{idVendor}=="03eb", ATTR{idProduct}=="800c", SYMLINK+="airspyhf-%k", TAGS+="uaccess"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 # Based heavily upon the libftdi cmake setup.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 project(airspyhf-tools C)
 set(MAJOR_VERSION 0)
 set(MINOR_VERSION 1)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -68,7 +68,21 @@ endif()
 ########################################################################
 # Install udev rules
 ########################################################################
+set(RULE_TEXT "ATTR{idVendor}==\"03eb\", ATTR{idProduct}==\"800c\", SYMLINK+=\"airspyhf-%k\", TAGS+=\"uaccess\"")
+set(REMOTE_USER_GROUP "plugdev")
+option(REMOTE_USER_RULES "Install udev rules for remote usage" OFF)
 option(INSTALL_UDEV_RULES "Install udev rules for AirSpy HF+" OFF)
+
+if (REMOTE_USER_RULES)
+    string (REPLACE "TAGS+=\"uaccess\"" "MODE=660, GROUP=${REMOTE_USER_GROUP}" RULE_TEXT ${RULE_TEXT})
+    set (INSTALL_UDEV_RULES ON)
+    message (STATUS "Udev rules created for remote users using GROUP=${REMOTE_USER_GROUP}")
+else (REMOTE_USER_RULES)
+    message (STATUS "Remote user rules not being used, set with -DREMOTE_USER_RULES=ON")
+endif (REMOTE_USER_RULES)
+
+file (WRITE "52-airspyhf.rules" "${RULE_TEXT}")
+
 if (INSTALL_UDEV_RULES)
     install (
         FILES 52-airspyhf.rules

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -68,18 +68,18 @@ endif()
 ########################################################################
 # Install udev rules
 ########################################################################
-set(RULE_TEXT "ATTR{idVendor}==\"03eb\", ATTR{idProduct}==\"800c\", SYMLINK+=\"airspyhf-%k\", TAGS+=\"uaccess\"")
 set(REMOTE_USER_GROUP "plugdev")
-option(REMOTE_USER_RULES "Install udev rules for remote usage" OFF)
+set(RULE_TEXT "ATTR{idVendor}==\"03eb\", ATTR{idProduct}==\"800c\", SYMLINK+=\"airspyhf-%k\", MODE=\"660\", GROUP=\"${REMOTE_USER_GROUP}\"")
+option(USE_UACCESS_RULES "Install udev uaccess rules" OFF)
 option(INSTALL_UDEV_RULES "Install udev rules for AirSpy HF+" OFF)
 
-if (REMOTE_USER_RULES)
-    string (REPLACE "TAGS+=\"uaccess\"" "MODE=660, GROUP=${REMOTE_USER_GROUP}" RULE_TEXT ${RULE_TEXT})
+if (USE_UACCESS_RULES)
+    string (REPLACE "MODE=\"660\", GROUP=\"${REMOTE_USER_GROUP}\"" "TAG+=\"uaccess\"" RULE_TEXT ${RULE_TEXT})
     set (INSTALL_UDEV_RULES ON)
-    message (STATUS "Udev rules created for remote users using GROUP=${REMOTE_USER_GROUP}")
-else (REMOTE_USER_RULES)
-    message (STATUS "Remote user rules not being used, set with -DREMOTE_USER_RULES=ON")
-endif (REMOTE_USER_RULES)
+    message (STATUS "Udev rules created for using uaccess")
+else (USE_UACCESS_RULES)
+    message (STATUS "Uaccess rules are not being used, set them with -DUSE_UACCESS_RULES=ON")
+endif (USE_UACCESS_RULES)
 
 file (WRITE "52-airspyhf.rules" "${RULE_TEXT}")
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -84,6 +84,28 @@ endif (USE_UACCESS_RULES)
 file (WRITE "52-airspyhf.rules" "${RULE_TEXT}")
 
 if (INSTALL_UDEV_RULES)
+
+#   Create REMOTE_USER_GROUP if it doesn't already exist
+    if (NOT (USE_UACCESS_RULES))
+        if (TARGET ${REMOTE_USER_GROUP})
+            message (STATUS "Group ${REMOTE_USER_GROUP} already exists")
+        else (TARGET ${REMOTE_USER_GROUP})
+            if (NOT (EXISTS "/etc/sysusers.d/${REMOTE_USER_GROUP}.conf"))
+                file (WRITE "${REMOTE_USER_GROUP}.conf" "g ${REMOTE_USER_GROUP} -")
+                install (
+                    FILES ${REMOTE_USER_GROUP}.conf
+                    DESTINATION "/etc/sysusers.d"
+                    COMPONENT "udev"
+                )
+                install (
+                    CODE "execute_process (COMMAND systemd-sysusers)"
+                )
+                message (STATUS "Group ${REMOTE_USER_GROUP} did not exist and will be created during the install process")
+            endif (NOT (EXISTS "/etc/sysusers.d/${REMOTE_USER_GROUP}.conf"))
+        endif (TARGET ${REMOTE_USER_GROUP})
+    endif (NOT (USE_UACCESS_RULES))
+
+#   Install rules file
     install (
         FILES 52-airspyhf.rules
         DESTINATION "/etc/udev/rules.d"


### PR DESCRIPTION
PR addresses issues raised in [Issue #46](https://github.com/airspy/airspyhf/issues/46) and quite possibly [Issue #50](https://github.com/airspy/airspyhf/issues/50) and [Issue #34](https://github.com/airspy/airspyhf/issues/34)
1. Reverts rules file to default uaccess configuration. This file may now actually be added to .gitignore as it is not really needed as part of the repo.
2. Modifies tools/CMakeLists.txt to dynamically create and install rules file in accordance with device usage: Adds a special option for networked device users that require MODE and GROUP, or retains the default uaccess tag. It then dynamically creates/installs the appropriate rules file, as needed.
3. Updates README with the appropriate usage instructions.