### PR TITLE
Fix: Use after free

### DIFF
--- a/libairspyhf/src/airspyhf.c
+++ b/libairspyhf/src/airspyhf.c
@@ -190,8 +190,8 @@ static int free_transfers(airspyhf_device_t* device)
 		{
 			if (device->transfers[transfer_index] != NULL)
 			{
-				libusb_free_transfer(device->transfers[transfer_index]);
 				free(device->transfers[transfer_index]->buffer);
+				libusb_free_transfer(device->transfers[transfer_index]);
 				device->transfers[transfer_index] = NULL;
 			}
 		}


### PR DESCRIPTION
I was working on a program that I wanted to use libairspyhf with. GDB kept telling me there was a sigtrap under airspyhf_close. 

I found that `free_transfers` contains a use-after-free bug where the libusb transfer pointer gets freed then the transfer pointer gets accessed again to free the transfer buffer. 

#### Valgrind Output of ./airspyhf_info before the change
```
AirSpy HF library version: 1.8.0

S/N: 0xDC528080D9494A8E
Part ID: 0x00000002
Firmware Version: R5.0.0-CD
Available sample rates: 912 kS/s 768 kS/s 650 kS/s 456 kS/s 384 kS/s 228 kS/s 192 kS/s

#### Valgrind Output of ./airspyhf_info before the change
==7308== Invalid read of size 8
==7308==    at 0x485CA61: free_transfers (airspyhf.c:194)
==7308==    by 0x485E97E: airspyhf_close (airspyhf.c:1159)
==7308==    by 0x1095BB: print_receiver_data (airspyhf_info.c:76)
==7308==    by 0x1098DA: main (airspyhf_info.c:170)
==7308==  Address 0x4e07440 is 208 bytes inside a block of size 224 free'd
==7308==    at 0x484988F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7308==    by 0x485CA4B: free_transfers (airspyhf.c:193)
==7308==    by 0x485E97E: airspyhf_close (airspyhf.c:1159)
==7308==    by 0x1095BB: print_receiver_data (airspyhf_info.c:76)
==7308==    by 0x1098DA: main (airspyhf_info.c:170)
==7308==  Block was alloc'd at
==7308==    at 0x484D953: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==7308==    by 0x4B87BFA: libusb_alloc_transfer (in /usr/lib/x86_64-linux-gnu/libusb-1.0.so.0.4.0)
==7308==    by 0x485CC57: allocate_transfers (airspyhf.c:242)
==7308==    by 0x485E694: airspyhf_open_init (airspyhf.c:1068)
==7308==    by 0x485E8DC: airspyhf_open_sn (airspyhf.c:1130)
==7308==    by 0x1098CA: main (airspyhf_info.c:169)
==7308== 
==7308== 
==7308== HEAP SUMMARY:
==7308==     in use at exit: 0 bytes in 0 blocks
==7308==   total heap usage: 8,348 allocs, 8,348 frees, 2,007,168 bytes allocated
==7308== 
==7308== All heap blocks were freed -- no leaks are possible
==7308== 
==7308== For lists of detected and suppressed errors, rerun with: -s
==7308== ERROR SUMMARY: 16 errors from 1 contexts (suppressed: 0 from 0)
```

#### Valgrind Output of ./airspyhf_info after the change
```
==7637== Memcheck, a memory error detector
==7637== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==7637== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==7637== Command: ./airspyhf_info
==7637== 
AirSpy HF library version: 1.8.0

S/N: 0xDC528080D9494A8E
Part ID: 0x00000002
Firmware Version: R5.0.0-CD
Available sample rates: 912 kS/s 768 kS/s 650 kS/s 456 kS/s 384 kS/s 228 kS/s 192 kS/s

==7637== 
==7637== HEAP SUMMARY:
==7637==     in use at exit: 0 bytes in 0 blocks
==7637==   total heap usage: 8,348 allocs, 8,348 frees, 2,007,168 bytes allocated
==7637== 
==7637== All heap blocks were freed -- no leaks are possible
==7637== 
==7637== For lists of detected and suppressed errors, rerun with: -s
==7637== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```