### PR TITLE
cmake: fix GCC 15 build failure and add INSTALL_STATIC_LIBS option

### DIFF
--- a/libairspyhf/src/CMakeLists.txt
+++ b/libairspyhf/src/CMakeLists.txt
@@ -41,11 +41,16 @@ use_c99()
 set(c_sources ${CMAKE_CURRENT_SOURCE_DIR}/airspyhf.c ${CMAKE_CURRENT_SOURCE_DIR}/iqbalancer.c CACHE INTERNAL "List of C sources")
 set(c_headers ${CMAKE_CURRENT_SOURCE_DIR}/airspyhf.h ${CMAKE_CURRENT_SOURCE_DIR}/iqbalancer.h ${CMAKE_CURRENT_SOURCE_DIR}/airspyhf_commands.h CACHE INTERNAL "List of C headers")
 
+option(INSTALL_STATIC_LIBS "Install static library" ON)
+
 # Dynamic library
 add_library(airspyhf SHARED ${c_sources} ${AIRSPYHF_DLL_SRCS})
 set_target_properties(airspyhf PROPERTIES VERSION ${AIRSPYHF_VER_MAJOR}.${AIRSPYHF_VER_MINOR}.${AIRSPYHF_VER_REVISION})
 set_target_properties(airspyhf PROPERTIES SOVERSION 0)
 
+set_target_properties(airspyhf PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+
+if(INSTALL_STATIC_LIBS)
 # Static library
 add_library(airspyhf-static STATIC ${c_sources})
 if(MSVC)
@@ -53,9 +58,8 @@ if(MSVC)
 else()
 	set_target_properties(airspyhf-static PROPERTIES OUTPUT_NAME "airspyhf")
 endif()
-
-set_target_properties(airspyhf PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 set_target_properties(airspyhf-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+endif(INSTALL_STATIC_LIBS)
 
 include(CheckFunctionExists)
 
@@ -92,10 +96,12 @@ if( ${UNIX} )
            LIBRARY DESTINATION lib${LIB_SUFFIX}
            COMPONENT sharedlibs
            )
+   if(INSTALL_STATIC_LIBS)
    install(TARGETS airspyhf-static
            ARCHIVE DESTINATION lib${LIB_SUFFIX}
            COMPONENT staticlibs
            )
+   endif(INSTALL_STATIC_LIBS)
    install(FILES ${c_headers}
            DESTINATION include/${PROJECT_NAME}
            COMPONENT headers
@@ -107,10 +113,12 @@ if( ${WIN32} )
            DESTINATION bin
            COMPONENT sharedlibs
            )
+   if(INSTALL_STATIC_LIBS)
    install(TARGETS airspyhf-static
            DESTINATION bin
            COMPONENT staticlibs
            )
+   endif(INSTALL_STATIC_LIBS)
    install(FILES ${c_headers}
            DESTINATION include/${PROJECT_NAME}
            COMPONENT headers

--- a/tools/src/CMakeLists.txt
+++ b/tools/src/CMakeLists.txt
@@ -24,6 +24,8 @@
 
 set(INSTALL_DEFAULT_BINDIR "bin" CACHE STRING "Appended to CMAKE_INSTALL_PREFIX")
 
+set(CMAKE_C_STANDARD 99)
+
 if(MSVC)
 add_library(libgetopt_static STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../getopt/getopt.c


### PR DESCRIPTION
## Fix 1: GCC 15 build failure (`tools/src/CMakeLists.txt`)

GCC 15 defaults to C23, which promotes `bool` to a keyword. `airspyhf_rx.c` contains:

```c
#if !defined __cplusplus
#ifndef bool
typedef int bool;   // error: 'bool' cannot be defined via 'typedef' with -std=c23
```

`libairspyhf` already enforces C99 via its `use_c99()` macro (which sets `CMAKE_C_STANDARD 99`), but the tools cmake has no C standard set, so it picks up the compiler default. The fix is a single line in `tools/src/CMakeLists.txt`:

```cmake
set(CMAKE_C_STANDARD 99)
```

## Fix 2: Add `INSTALL_STATIC_LIBS` cmake option (`libairspyhf/src/CMakeLists.txt`)

The build system unconditionally builds and installs `libairspyhf.a` even when only the shared library is needed. This causes QA warnings in Linux distributions (e.g. Gentoo tinderbox) when a package installs `.a` files without a `static-libs` opt-in.

A new `INSTALL_STATIC_LIBS` option (default `ON` for full backwards compatibility) controls both building and installation of the static library:

```bash
cmake -DINSTALL_STATIC_LIBS=OFF ..
```

Packagers who only need the shared library can use `-DINSTALL_STATIC_LIBS=OFF` to skip the static build entirely.